### PR TITLE
Fix for fastpack: Don't build if static libssl is present

### DIFF
--- a/esy/build.sh
+++ b/esy/build.sh
@@ -4,8 +4,6 @@ echo "Checking for existing SSL installs..."
 ls -a /lib/libssl*
 ls -a /usr/lib/libssl*
 
-exit 1
-
 if [ -e /usr/lib/libssl.a ] then
     echo "libssl.a already available; not building"
 else

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -1,9 +1,15 @@
 cd _build
 
+echo "Checking for existing SSL installs..."
 ls -a /lib/libssl*
 ls -a /usr/lib/libssl*
 
 exit 1
 
-# make VERBOSE=1
-# make install VERBOSE=1
+if [ -e /usr/lib/libssl.a ] then
+    echo "libssl.a already available; not building"
+else
+    make VERBOSE=1
+    make install VERBOSE=1
+fi
+

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -4,7 +4,7 @@ echo "Checking for existing SSL installs..."
 ls -a /lib/libssl*
 ls -a /usr/lib/libssl*
 
-if [ -e /usr/lib/libssl.a ] then
+if [ -e /usr/lib/libssl.a ]; then
     echo "libssl.a already available; not building"
 else
     make VERBOSE=1

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -1,7 +1,7 @@
 cd _build
 
-ls -a /lib/libssl.o
-ls -a /usr/lib/libssl.o
+ls -a /lib/libssl*
+ls -a /usr/lib/libssl*
 
 exit 1
 

--- a/esy/build.sh
+++ b/esy/build.sh
@@ -1,4 +1,9 @@
 cd _build
 
-make VERBOSE=1
-make install VERBOSE=1
+ls -a /lib/libssl.o
+ls -a /usr/lib/libssl.o
+
+exit 1
+
+# make VERBOSE=1
+# make install VERBOSE=1


### PR DESCRIPTION
This is a fix needed for building `fastpack` on Alpine Linux. This dependency is problematic to build there, so we will defer to using an installed static library if available.

We may want to control this behavior with an environment variable later - there are cases where we'd wnat to ignore whatever is installed and always use the built version.